### PR TITLE
add plangularConfigProvider info to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,22 @@ Use template conditionals to show a loading state.
 ---
 
 
+## Configuring Plangular
+
+#### plangularConfigProvider *(AngularJS only)*
+
+Plangular works out of the box, but if you want to configure it to use your own Soundcloud client ID, you can modify `plangularConfigProvider` in a config block:
+
+```js
+.config(function(plangularConfigProvider){
+  plangularConfigProvider.clientId = '[YOUR-CLIENT-ID-HERE]';
+})
+```
+
+
+---
+
+
 ## SoundCloud API
 
 Example JSON object:


### PR DESCRIPTION
Whipped up a quick addendum to the docs for plangularConfigProvider. (I wasn't sure exactly where in the docs to put this, but this seemed like a good place.)