### PR TITLE
Use schemeless urls for the API

### DIFF
--- a/src/v-backup.js
+++ b/src/v-backup.js
@@ -22,7 +22,7 @@ var plangular = {};
 var jsonp = require('jsonp');
 
 plangular.clientID = '0d33361983f16d2527b01fbf6408b7d7';
-plangular.api = 'http://api.soundcloud.com/resolve.json';
+plangular.api = '//api.soundcloud.com/resolve.json';
 plangular.data = {};
 
 

--- a/src/v-plangular.js
+++ b/src/v-plangular.js
@@ -13,7 +13,7 @@
 
 var plangular = {};
 plangular.clientID = '0d33361983f16d2527b01fbf6408b7d7';
-plangular.api = 'http://api.soundcloud.com/resolve.json';
+plangular.api = '//api.soundcloud.com/resolve.json';
 plangular.data = {};
 
 module.exports = plangular;


### PR DESCRIPTION
Hey @jxnblk! On [Jukely Unlimited](https://unlimited.jukely.com) we would like to play songs on a `https` page so we gotta hit the `https` API endpoint. Cool!
