### PR TITLE
Fixes #41

### DIFF
--- a/src/ng-plangular.js
+++ b/src/ng-plangular.js
@@ -110,6 +110,19 @@ plangular.directive('plangular', ['$http', 'plangularConfig', function ($http, p
       if (!audio.readyState) return false;
       var xpos = e.offsetX / e.target.offsetWidth;
       audio.currentTime = (xpos * audio.duration);
+    },
+
+    destroy: function() {
+      this.currentTrack = false;
+      this.playing = false;
+      this.tracks = [];
+      this.i = 0;
+      this.playlistIndex = 0;
+      this.currentTime = 0;
+      this.duration = 0;
+      audio.pause();
+      if (!audio.readyState) return false;
+      audio.currentTime = 0;
     }
 
   };
@@ -131,7 +144,7 @@ plangular.directive('plangular', ['$http', 'plangularConfig', function ($http, p
     restrict: 'A',
     scope: true,
 
-    link: function (scope, elem, attrs) {
+    link: function postLink(scope, elem, attrs) {
 
       var src = attrs.plangular;
       var params = { url: src, client_id: clientId, callback: 'JSON_CALLBACK' }
@@ -156,6 +169,7 @@ plangular.directive('plangular', ['$http', 'plangularConfig', function ($http, p
       } else if (player.data[src]) {
         scope.track = player.data[src];
         addKeys(scope.track);
+        player.load(scope.track, scope.index);
       } else {
         $http.jsonp('//api.soundcloud.com/resolve.json', { params: params }).success(function(data){
           scope.track = data;
@@ -199,6 +213,10 @@ plangular.directive('plangular', ['$http', 'plangularConfig', function ($http, p
           player.seek(e);
         }
       };
+
+      scope.$on('$destroy', function() {
+        player.destroy();
+      });
 
     }
 


### PR DESCRIPTION
- The issue was that the "Player becomes unresponsive when changing views." This is because the player remembers its current state. This becomes problematic for a few reasons. One, on page change if the player is playing it continues to play (I am unsure if this is intentional but I find this user experience to be broken because the user can't stop the audio unless the page has a player on it). Two, when the user returns to a page with a player and presses pause it causes a out of bound error. This is because this.tracks[i] is undefined due to the player remembering the current state, the index is increased by one from its previous state and because it was not reset, it is now outside of the bounds of the array.
- My solution is to reset the player when the directive is destroyed. I reset all values to their initial value except for the data. The data is left untouched so that we can avoid duplicate calls to the sound cloud API. I also load the track into the player when its found in the player's data object, otherwise the player will not have all the tracks because we reset the array on the directive's destroy callback.
