### PR TITLE
fix broken secret links

### DIFF
--- a/src/plangular.js
+++ b/src/plangular.js
@@ -49,7 +49,8 @@ plangular.directive('plangular', ['$timeout', 'plangularConfig', function($timeo
 
       function createSrc(track) {
         if (track.stream_url) {
-          track.src = track.stream_url + '?client_id=' + client_id;
+          var sep = track.stream_url.indexOf('?') === -1 ? '?' : '&'
+          track.src = track.stream_url + sep + 'client_id=' + client_id;
         }
         return track;
       }
@@ -153,4 +154,3 @@ plangular.provider('plangularConfig', function() {
 
 
 module.exports = 'plangular';
-


### PR DESCRIPTION
For secret tracks, the `stream_url` is in the format of  `"https://api.soundcloud.com/tracks/213377310/stream?secret_token=XXXXX"`. `createSrc` appends a question mark without checking if there already is one in the URL which breaks the link. This fixes that :)